### PR TITLE
Attempt to make the plugin work again in newer Eclipse releases

### DIFF
--- a/parent/bundles/com.google.eclipse.mechanic/META-INF/MANIFEST.MF
+++ b/parent/bundles/com.google.eclipse.mechanic/META-INF/MANIFEST.MF
@@ -1,8 +1,9 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
+Automatic-Module-Name: com.google.eclipse.mechanic
 Bundle-Name: Workspace Mechanic Plug-in
 Bundle-SymbolicName: com.google.eclipse.mechanic;singleton:=true
-Bundle-Version: 0.5.2.qualifier
+Bundle-Version: 0.6.0.qualifier
 Bundle-ClassPath: .,
  lib/gson.jar,
  lib/guava.jar
@@ -13,6 +14,6 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.5.0,4.0.0)",
  org.eclipse.core.variables;bundle-version="[3.2.200,4.0.0)",
  org.eclipse.ui.forms;bundle-version="[3.4.0,4.0.0)",
  org.eclipse.ui;bundle-version="[3.4.0,4.0.0)"
-Bundle-RequiredExecutionEnvironment: J2SE-1.5
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Export-Package: com.google.eclipse.mechanic

--- a/parent/bundles/com.google.eclipse.mechanic/pom.xml
+++ b/parent/bundles/com.google.eclipse.mechanic/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.google.eclipse.mechanic</groupId>
         <artifactId>bundles</artifactId>
-        <version>0.5.2-SNAPSHOT</version>
+        <version>0.6.0-SNAPSHOT</version>
     </parent>
     <artifactId>com.google.eclipse.mechanic</artifactId>
     <packaging>eclipse-plugin</packaging>
@@ -13,12 +13,10 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>12.0.1</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>1.6</version>
         </dependency>
     </dependencies>
 </project>

--- a/parent/bundles/com.google.eclipse.mechanic/src/com/google/eclipse/mechanic/LastModifiedPreferencesFileTask.java
+++ b/parent/bundles/com.google.eclipse.mechanic/src/com/google/eclipse/mechanic/LastModifiedPreferencesFileTask.java
@@ -25,6 +25,7 @@ import org.eclipse.core.runtime.preferences.IExportedPreferences;
 import org.eclipse.core.runtime.preferences.IPreferenceFilter;
 import org.eclipse.core.runtime.preferences.IPreferencesService;
 import org.eclipse.core.runtime.preferences.InstanceScope;
+import org.eclipse.core.runtime.preferences.PreferenceFilterEntry;
 
 import com.google.common.base.Preconditions;
 import com.google.eclipse.mechanic.plugin.core.IMechanicPreferences;
@@ -144,8 +145,7 @@ public abstract class LastModifiedPreferencesFileTask extends CompositeTask {
             };
         }
 
-        @SuppressWarnings("rawtypes") // Eclipse doesn't do generics.
-        public Map getMapping(String scope) {
+        public Map<String, PreferenceFilterEntry[]> getMapping(String scope) {
             return null;
         }
     };

--- a/parent/bundles/com.google.eclipse.mechanic/src/com/google/eclipse/mechanic/MechanicService.java
+++ b/parent/bundles/com.google.eclipse.mechanic/src/com/google/eclipse/mechanic/MechanicService.java
@@ -18,7 +18,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
-import org.eclipse.core.runtime.SubProgressMonitor;
+import org.eclipse.core.runtime.SubMonitor;
 import org.eclipse.core.runtime.jobs.IJobChangeEvent;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.core.runtime.jobs.JobChangeAdapter;
@@ -276,7 +276,7 @@ public final class MechanicService implements IMechanicService {
     monitor.worked(1);
 
     // test tasks and figure out which ones are blocked
-    updateTaskStatus(new SubProgressMonitor(monitor, collector.getTasks().size()));
+    updateTaskStatus(monitor);
 
     monitor.worked(1);
   }
@@ -289,12 +289,12 @@ public final class MechanicService implements IMechanicService {
 
     Set<String> blocked = mechanicPreferences.getBlockedTaskIds();
 
-    monitor.beginTask("", collector.getTasks().size());
+    SubMonitor subMonitor = SubMonitor.convert(monitor, collector.getTasks().size());
     try {
       taskStatus.clear();
 
       for (Task task : collector.getTasks()) {
-        monitor.subTask("Evaluating: " + task.getId());
+        subMonitor.subTask("Evaluating: " + task.getId());
 
         if (blocked.contains(task.getId())) {
           taskStatus.put(task, TaskStatus.BLOCKED);
@@ -306,10 +306,10 @@ public final class MechanicService implements IMechanicService {
         } catch (RuntimeException e) {
           log.logError(e, "Evaluator test failed for task %s", task);
         }
-        monitor.worked(1);
+        subMonitor.worked(1);
       }
     } finally {
-      monitor.done();
+      subMonitor.done();
     }
   }
 

--- a/parent/bundles/com.google.eclipse.mechanic/src/com/google/eclipse/mechanic/TaskScanner.java
+++ b/parent/bundles/com.google.eclipse.mechanic/src/com/google/eclipse/mechanic/TaskScanner.java
@@ -9,8 +9,6 @@
 
 package com.google.eclipse.mechanic;
 
-import com.google.eclipse.mechanic.TaskCollector;
-
 /**
  * Simple interface for collecting tasks.
  *

--- a/parent/bundles/com.google.eclipse.mechanic/src/com/google/eclipse/mechanic/core/keybinding/KbaBootstrapper.java
+++ b/parent/bundles/com.google.eclipse.mechanic/src/com/google/eclipse/mechanic/core/keybinding/KbaBootstrapper.java
@@ -319,6 +319,7 @@ public final class KbaBootstrapper {
     return result;
   }
 
+  @SafeVarargs
   private static <T> Iterable<T> concat(ImmutableList<T> list, T... toConcat) {
     List<T> result = Lists.newArrayList(list);
     for (T t : toConcat) {

--- a/parent/bundles/com.google.eclipse.mechanic/src/com/google/eclipse/mechanic/core/keybinding/KeyBindingsManualFormatter.java
+++ b/parent/bundles/com.google.eclipse.mechanic/src/com/google/eclipse/mechanic/core/keybinding/KeyBindingsManualFormatter.java
@@ -25,7 +25,6 @@ import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterables;
-import com.google.common.io.Closeables;
 
 /**
  * Class that formats the keybindings by sweat and tears.
@@ -105,12 +104,8 @@ class KeyBindingsManualFormatter {
       String description) throws FileNotFoundException, IOException {
     String output = getBindingsPrintout(bindingType, kbaChangeSet, description);
     File file = outputLocation.toFile();
-    PrintStream stream = null;
-    try {
-      stream = new PrintStream(new FileOutputStream(file));
+    try (PrintStream stream = new PrintStream(new FileOutputStream(file))) {
       stream.print(output);
-    } finally {
-      Closeables.closeQuietly(stream);
     }
   }
   

--- a/parent/bundles/com.google.eclipse.mechanic/src/com/google/eclipse/mechanic/internal/ClassFileTaskScanner.java
+++ b/parent/bundles/com.google.eclipse.mechanic/src/com/google/eclipse/mechanic/internal/ClassFileTaskScanner.java
@@ -141,10 +141,8 @@ public final class ClassFileTaskScanner extends ResourceTaskScanner {
   private Task createInstance(Class<?> clazz) {
     Task task = null;
     try {
-      task = (Task) clazz.newInstance();
-    } catch (InstantiationException e) {
-      throw new RuntimeException(e);
-    } catch (IllegalAccessException e) {
+      task = (Task) clazz.getDeclaredConstructor().newInstance();
+    } catch (ReflectiveOperationException e) {
       throw new RuntimeException(e);
     } catch (LinkageError e) {
       throw new RuntimeException(e);

--- a/parent/bundles/com.google.eclipse.mechanic/src/com/google/eclipse/mechanic/internal/EpfFileModelWriter.java
+++ b/parent/bundles/com.google.eclipse.mechanic/src/com/google/eclipse/mechanic/internal/EpfFileModelWriter.java
@@ -33,9 +33,9 @@ public class EpfFileModelWriter {
 
   public static void write(EpfFileModel model, OutputStream outputStream) throws IOException {
     PrintWriter commentPrintWriter = new PrintWriter(outputStream);
-    commentPrintWriter.format("# @title %s\n", model.getTitle());
-    commentPrintWriter.format("# @description %s\n", model.getDescription());
-    commentPrintWriter.format("# @task_type %s\n#\n", model.getTaskType().toString());
+    commentPrintWriter.format("# @title %s%n", model.getTitle());
+    commentPrintWriter.format("# @description %s%n", model.getDescription());
+    commentPrintWriter.format("# @task_type %s%n#%n", model.getTaskType().toString());
     commentPrintWriter.println(
         "# Created by the Workspace Mechanic Preference Recorder");
     commentPrintWriter.flush();

--- a/parent/bundles/com.google.eclipse.mechanic/src/com/google/eclipse/mechanic/internal/FileTaskProvider.java
+++ b/parent/bundles/com.google.eclipse.mechanic/src/com/google/eclipse/mechanic/internal/FileTaskProvider.java
@@ -19,6 +19,7 @@ import java.util.logging.Logger;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hashing;
 import com.google.common.io.Files;
 import com.google.eclipse.mechanic.ICollector;
@@ -67,7 +68,7 @@ public final class FileTaskProvider extends ResourceTaskProvider {
     }
 
     public long computeMD5() throws IOException {
-      return Files.hash(file, Hashing.md5()).asLong();
+      return Files.asByteSource(file).hash(Hashing.md5()).asLong();
     }
   }
 

--- a/parent/bundles/com.google.eclipse.mechanic/src/com/google/eclipse/mechanic/internal/UriTaskProvider.java
+++ b/parent/bundles/com.google.eclipse.mechanic/src/com/google/eclipse/mechanic/internal/UriTaskProvider.java
@@ -15,8 +15,7 @@ import java.net.URI;
 
 import com.google.common.base.Preconditions;
 import com.google.common.hash.Hashing;
-import com.google.common.io.ByteStreams;
-import com.google.common.io.InputSupplier;
+import com.google.common.io.ByteSource;
 import com.google.eclipse.mechanic.ICollector;
 import com.google.eclipse.mechanic.IResourceTaskReference;
 import com.google.eclipse.mechanic.plugin.core.ResourceTaskProvider;
@@ -66,12 +65,13 @@ public final class UriTaskProvider extends ResourceTaskProvider {
     }
 
     public long computeMD5() throws IOException {
-      InputSupplier<InputStream> supplier = new InputSupplier<InputStream>() {
-        public InputStream getInput() throws IOException {
+      ByteSource supplier = new ByteSource() {
+        @Override
+        public InputStream openStream() throws IOException {
           return newInputStream();
         }
       };
-      return ByteStreams.hash(supplier, Hashing.md5()).asLong();
+      return supplier.hash(Hashing.md5()).asLong();
     }
   }
 

--- a/parent/bundles/pom.xml
+++ b/parent/bundles/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.google.eclipse.mechanic</groupId>
         <artifactId>parent</artifactId>
-        <version>0.5.2-SNAPSHOT</version>
+        <version>0.6.0-SNAPSHOT</version>
     </parent>
     <modules>
         <module>com.google.eclipse.mechanic</module>

--- a/parent/config/pom.xml
+++ b/parent/config/pom.xml
@@ -7,6 +7,6 @@
     <parent>
         <groupId>com.google.eclipse.mechanic</groupId>
         <artifactId>parent</artifactId>
-        <version>0.5.2-SNAPSHOT</version>
+        <version>0.6.0-SNAPSHOT</version>
     </parent>
 </project>

--- a/parent/examples/com.google.eclipse.mechanic.samples/META-INF/MANIFEST.MF
+++ b/parent/examples/com.google.eclipse.mechanic.samples/META-INF/MANIFEST.MF
@@ -1,14 +1,15 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
+Automatic-Module-Name: com.google.eclipse.mechanic.samples
 Bundle-Name: Workspace Mechanic Samples
 Bundle-SymbolicName: com.google.eclipse.mechanic.samples;singleton:=true
-Bundle-Version: 0.5.2.qualifier
+Bundle-Version: 0.6.0.qualifier
 Bundle-Vendor: Robert Konigsberg
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
  com.google.eclipse.mechanic,
  com.google.eclipse.mechanic
-Bundle-RequiredExecutionEnvironment: J2SE-1.5
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .,
  lib/guava.jar

--- a/parent/examples/com.google.eclipse.mechanic.samples/pom.xml
+++ b/parent/examples/com.google.eclipse.mechanic.samples/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.google.eclipse.mechanic</groupId>
         <artifactId>examples</artifactId>
-        <version>0.5.2-SNAPSHOT</version>
+        <version>0.6.0-SNAPSHOT</version>
     </parent>
     <artifactId>com.google.eclipse.mechanic.samples</artifactId>
     <packaging>eclipse-plugin</packaging>
@@ -13,7 +13,6 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>12.0.1</version>
         </dependency>
     </dependencies>
 </project>

--- a/parent/examples/com.google.eclipse.mechanic.samples/src/com/google/eclipse/mechanic/samples/InMemoryTaskProvider.java
+++ b/parent/examples/com.google.eclipse.mechanic.samples/src/com/google/eclipse/mechanic/samples/InMemoryTaskProvider.java
@@ -18,8 +18,7 @@ import java.util.Map;
 import com.google.common.base.Joiner;
 import com.google.common.collect.Maps;
 import com.google.common.hash.Hashing;
-import com.google.common.io.ByteStreams;
-import com.google.common.io.InputSupplier;
+import com.google.common.io.ByteSource;
 import com.google.eclipse.mechanic.ICollector;
 import com.google.eclipse.mechanic.IResourceTaskProvider;
 import com.google.eclipse.mechanic.IResourceTaskReference;
@@ -88,12 +87,13 @@ public class InMemoryTaskProvider implements IResourceTaskProvider {
     }
 
     public long computeMD5() throws IOException {
-      InputSupplier<InputStream> supplier = new InputSupplier<InputStream>() {
-        public InputStream getInput() throws IOException {
+      ByteSource supplier = new ByteSource() {
+        @Override
+        public InputStream openStream() throws IOException {
           return newInputStream();
         }
       };
-      return ByteStreams.hash(supplier, Hashing.md5()).asLong();
+      return supplier.hash(Hashing.md5()).asLong();
     }
 
     @Override

--- a/parent/examples/pom.xml
+++ b/parent/examples/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.google.eclipse.mechanic</groupId>
         <artifactId>parent</artifactId>
-        <version>0.5.2-SNAPSHOT</version>
+        <version>0.6.0-SNAPSHOT</version>
     </parent>
     <modules>
         <module>com.google.eclipse.mechanic.samples</module>

--- a/parent/features/mechanic/feature.xml
+++ b/parent/features/mechanic/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="com.google.eclipse.mechanic.feature"
       label="Workspace Mechanic"
-      version="0.5.2.qualifier"
+      version="0.6.0.qualifier"
       provider-name="Google, Inc.">
 
    <description url="https://github.com/alfsch/alfsch.workspacemechanic.update">

--- a/parent/features/mechanic/pom.xml
+++ b/parent/features/mechanic/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.google.eclipse.mechanic</groupId>
         <artifactId>features</artifactId>
-        <version>0.5.2-SNAPSHOT</version>
+        <version>0.6.0-SNAPSHOT</version>
     </parent>
     <artifactId>com.google.eclipse.mechanic.feature</artifactId>
     <packaging>eclipse-feature</packaging>

--- a/parent/features/pom.xml
+++ b/parent/features/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.google.eclipse.mechanic</groupId>
         <artifactId>parent</artifactId>
-        <version>0.5.2-SNAPSHOT</version>
+        <version>0.6.0-SNAPSHOT</version>
     </parent>
     <modules>
         <module>mechanic</module>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1,21 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
-    xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<project
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.google.eclipse.mechanic</groupId>
     <artifactId>parent</artifactId>
-    <version>0.5.2-SNAPSHOT</version>
+    <version>0.6.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <properties>
-        <tycho-version>0.25.0</tycho-version>
-        <findbugs-plugin-version>3.0.3</findbugs-plugin-version>
-        <pmd-plugin-version>3.6</pmd-plugin-version>
-        <checkstyle-plugin-version>2.17</checkstyle-plugin-version>
+        <tycho-version>3.0.5</tycho-version>
+        <tycho-extras-version>2.7.5</tycho-extras-version>
+        <findbugs-plugin-version>3.0.5</findbugs-plugin-version>
+        <pmd-plugin-version>3.21.0</pmd-plugin-version>
+        <checkstyle-plugin-version>3.3.0</checkstyle-plugin-version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <sonar.host.url>http://sonarqube-1.12ececdd.cont.dockerapp.io:9000</sonar.host.url>
         <sonar.login>4bd61011f72af5e20222908eb455e43d88a8a26e</sonar.login>
         <sonar.projectName>Eclipse Workspace-Mechanic</sonar.projectName>
-        <sonar.java.source>1.6</sonar.java.source>
+        <sonar.java.source>17</sonar.java.source>
         <sonar.jacoco.reportPath>${user.dir}/target/jacoco.exec</sonar.jacoco.reportPath>
     </properties>
     <modules>
@@ -28,19 +31,21 @@
     </modules>
     <repositories>
         <repository>
-            <id>eclipse-indigo</id>
-            <url>http://download.eclipse.org/releases/indigo</url>
+            <id>eclipse-2023-06</id>
+            <url>https://download.eclipse.org/releases/2023-06/</url>
             <layout>p2</layout>
         </repository>
     </repositories>
     <build>
         <pluginManagement>
             <plugins>
+<!--
                 <plugin>
                     <groupId>org.sonarsource.scanner.maven</groupId>
                     <artifactId>sonar-maven-plugin</artifactId>
                     <version>3.0.1</version>
                 </plugin>
+-->
                 <plugin>
                     <groupId>org.eclipse.tycho</groupId>
                     <artifactId>tycho-maven-plugin</artifactId>
@@ -54,11 +59,11 @@
                 </plugin>
                 <plugin>
                     <groupId>org.eclipse.tycho</groupId>
-                    <artifactId>maven-osgi-compiler-plugin</artifactId>
+                    <artifactId>tycho-compiler-plugin</artifactId>
                     <version>${tycho-version}</version>
                     <configuration>
-                        <source>1.7</source>
-                        <target>1.7</target>
+                        <source>17</source>
+                        <target>17</target>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -75,29 +80,32 @@
                     <groupId>org.eclipse.tycho</groupId>
                     <artifactId>tycho-packaging-plugin</artifactId>
                     <version>${tycho-version}</version>
+<!--
                     <dependencies>
                         <dependency>
                             <groupId>org.eclipse.tycho.extras</groupId>
                             <artifactId>tycho-buildtimestamp-jgit</artifactId>
-                            <version>${tycho-version}</version>
+                            <version>${tycho-extras-version}</version>
                         </dependency>
                     </dependencies>
                     <configuration>
                         <timestampProvider>jgit</timestampProvider>
                         <jgit.ignore>
                             pom.xml
+                            .gitignore
                         </jgit.ignore>
                         <jgit.dirtyWorkingTree>ignore</jgit.dirtyWorkingTree>
                     </configuration>
+-->
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>2.10</version>
+                    <version>3.6.0</version>
                     <executions>
                         <execution>
                             <id>copy-dependencies</id>
-                            <phase>initialize</phase>
+                            <phase>pre-integration-test</phase>
                             <goals>
                                 <goal>copy-dependencies</goal>
                             </goals>
@@ -114,7 +122,7 @@
                 <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>0.7.7.201606060606</version>
+                    <version>0.8.10</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
@@ -150,7 +158,7 @@
             </plugin>
             <plugin>
                 <groupId>org.eclipse.tycho</groupId>
-                <artifactId>maven-osgi-compiler-plugin</artifactId>
+                <artifactId>tycho-compiler-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.eclipse.tycho</groupId>
@@ -240,4 +248,23 @@
             </plugin>
         </plugins>
     </reporting>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>32.1.2-jre</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.code.gson</groupId>
+                <artifactId>gson</artifactId>
+                <version>2.10.1</version>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>5.4.0</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 </project>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -9,11 +9,11 @@
     <version>0.6.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <properties>
-        <tycho-version>3.0.5</tycho-version>
-        <tycho-extras-version>2.7.5</tycho-extras-version>
+        <tycho-version>4.0.10</tycho-version>
+        <tycho-extras-version>4.0.10</tycho-extras-version>
         <findbugs-plugin-version>3.0.5</findbugs-plugin-version>
-        <pmd-plugin-version>3.21.0</pmd-plugin-version>
-        <checkstyle-plugin-version>3.3.0</checkstyle-plugin-version>
+        <pmd-plugin-version>3.26.0</pmd-plugin-version>
+        <checkstyle-plugin-version>3.6.0</checkstyle-plugin-version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <sonar.host.url>http://sonarqube-1.12ececdd.cont.dockerapp.io:9000</sonar.host.url>
         <sonar.login>4bd61011f72af5e20222908eb455e43d88a8a26e</sonar.login>
@@ -31,8 +31,8 @@
     </modules>
     <repositories>
         <repository>
-            <id>eclipse-2023-06</id>
-            <url>https://download.eclipse.org/releases/2023-06/</url>
+            <id>eclipse-2024-12</id>
+            <url>https://download.eclipse.org/releases/2024-12/</url>
             <layout>p2</layout>
         </repository>
     </repositories>
@@ -43,7 +43,7 @@
                 <plugin>
                     <groupId>org.sonarsource.scanner.maven</groupId>
                     <artifactId>sonar-maven-plugin</artifactId>
-                    <version>3.0.1</version>
+                    <version>5.0.0.4389</version>
                 </plugin>
 -->
                 <plugin>
@@ -101,7 +101,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>3.6.0</version>
+                    <version>3.8.1</version>
                     <executions>
                         <execution>
                             <id>copy-dependencies</id>
@@ -122,7 +122,7 @@
                 <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>0.8.10</version>
+                    <version>0.8.12</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
@@ -253,17 +253,17 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>32.1.2-jre</version>
+                <version>33.3.1-jre</version>
             </dependency>
             <dependency>
                 <groupId>com.google.code.gson</groupId>
                 <artifactId>gson</artifactId>
-                <version>2.10.1</version>
+                <version>2.11.0</version>
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
-                <version>5.4.0</version>
+                <version>5.14.2</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/parent/releng/pom.xml
+++ b/parent/releng/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.google.eclipse.mechanic</groupId>
         <artifactId>parent</artifactId>
-        <version>0.5.2-SNAPSHOT</version>
+        <version>0.6.0-SNAPSHOT</version>
     </parent>
     <modules>
         <module>update</module>

--- a/parent/releng/update/category.xml
+++ b/parent/releng/update/category.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-   <feature url="features/com.google.eclipse.mechanic.feature_0.5.2.qualifier.jar" id="com.google.eclipse.mechanic.feature" version="0.5.2.qualifier">
+   <feature url="features/com.google.eclipse.mechanic.feature_0.6.0.qualifier.jar" id="com.google.eclipse.mechanic.feature" version="0.6.0.qualifier">
       <category name="com.google.eclipse.mechanic"/>
    </feature>
    <category-def name="com.google.eclipse.mechanic" label="Workspace Mechanic Feature">

--- a/parent/releng/update/pom.xml
+++ b/parent/releng/update/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.google.eclipse.mechanic</groupId>
         <artifactId>releng</artifactId>
-        <version>0.5.2-SNAPSHOT</version>
+        <version>0.6.0-SNAPSHOT</version>
     </parent>
     <build>
         <plugins>

--- a/parent/tests/com.google.eclipse.mechanic.tests/META-INF/MANIFEST.MF
+++ b/parent/tests/com.google.eclipse.mechanic.tests/META-INF/MANIFEST.MF
@@ -1,10 +1,11 @@
 Bundle-ManifestVersion: 2
+Automatic-Module-Name: com.google.eclipse.mechanic.tests
 Bundle-Name: Mechanic Tests Fragment
 Bundle-SymbolicName: com.google.eclipse.mechanic.tests
-Bundle-Version: 0.5.2.qualifier
+Bundle-Version: 0.6.0.qualifier
 Bundle-Vendor: Google Inc.
 Require-Bundle: org.junit
 Fragment-Host: com.google.eclipse.mechanic
-Bundle-RequiredExecutionEnvironment: J2SE-1.5
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ClassPath: .,
  lib/mockito-all.jar

--- a/parent/tests/com.google.eclipse.mechanic.tests/pom.xml
+++ b/parent/tests/com.google.eclipse.mechanic.tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.google.eclipse.mechanic</groupId>
         <artifactId>tests</artifactId>
-        <version>0.5.2-SNAPSHOT</version>
+        <version>0.6.0-SNAPSHOT</version>
     </parent>
     <artifactId>com.google.eclipse.mechanic.tests</artifactId>
     <packaging>eclipse-test-plugin</packaging>
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>com.google.eclipse.mechanic</groupId>
             <artifactId>com.google.eclipse.mechanic</artifactId>
-            <version>0.5.2-SNAPSHOT</version>
+            <version>0.6.0-SNAPSHOT</version>
             <type>eclipse-plugin</type>
         </dependency>
     </dependencies>

--- a/parent/tests/com.google.eclipse.mechanic.tests/src/com/google/eclipse/mechanic/core/keybinding/KeyBindingsManualFormatterTest.java
+++ b/parent/tests/com.google.eclipse.mechanic.tests/src/com/google/eclipse/mechanic/core/keybinding/KeyBindingsManualFormatterTest.java
@@ -16,13 +16,12 @@ import com.google.eclipse.mechanic.core.keybinding.KbaChangeSet.Action;
 import com.google.eclipse.mechanic.core.keybinding.KbaChangeSet.KbaBindingList;
 import com.google.eclipse.mechanic.core.keybinding.KeyBindingsManualFormatter.BindingType;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.StringReader;
 import java.util.List;
 import java.util.Map;
-
-import junit.framework.Assert;
 
 /**
  * Tests for {@link KeyBindingsManualFormatter}

--- a/parent/tests/com.google.eclipse.mechanic.tests/src/com/google/eclipse/mechanic/core/keybinding/KeyBindingsParserTest.java
+++ b/parent/tests/com.google.eclipse.mechanic.tests/src/com/google/eclipse/mechanic/core/keybinding/KeyBindingsParserTest.java
@@ -14,15 +14,11 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import junit.framework.TestCase;
-
 import com.google.common.collect.Maps;
-import com.google.eclipse.mechanic.core.keybinding.KbaChangeSet;
-import com.google.eclipse.mechanic.core.keybinding.KbaBinding;
-import com.google.eclipse.mechanic.core.keybinding.KeyBindingsModel;
-import com.google.eclipse.mechanic.core.keybinding.KeyBindingsParser;
 import com.google.eclipse.mechanic.core.keybinding.KeyBindingsModel.KbaMetaData;
 import com.google.eclipse.mechanic.tests.internal.RunAsJUnitTest;
+
+import junit.framework.TestCase;
 
 @RunAsJUnitTest
 public class KeyBindingsParserTest extends TestCase {

--- a/parent/tests/com.google.eclipse.mechanic.tests/src/com/google/eclipse/mechanic/internal/BlockedTaskIdsParserTest.java
+++ b/parent/tests/com.google.eclipse.mechanic.tests/src/com/google/eclipse/mechanic/internal/BlockedTaskIdsParserTest.java
@@ -8,6 +8,7 @@
  *******************************************************************************/
 package com.google.eclipse.mechanic.internal;
 
+import java.io.File;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -30,7 +31,7 @@ public class BlockedTaskIdsParserTest extends TestCase {
   public void testParse() {
     assertResults(parser.parse(""));
     assertResults(parser.parse("x"), "x");
-    assertResults(parser.parse("x:y"), "x", "y");
+    assertResults(parser.parse("x" + File.pathSeparatorChar + "y"), "x", "y");
     assertResults(parser.parse(
         "['com.google.eclipse.path$Class@/Path/To/Thing', " +
             "'com.google.eclipse.path2@file://path/to/thing', " +

--- a/parent/tests/com.google.eclipse.mechanic.tests/src/com/google/eclipse/mechanic/internal/EpfFileModelWriterTest.java
+++ b/parent/tests/com.google.eclipse.mechanic.tests/src/com/google/eclipse/mechanic/internal/EpfFileModelWriterTest.java
@@ -11,9 +11,7 @@ package com.google.eclipse.mechanic.internal;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-
-import com.google.common.base.Splitter;
-import com.google.common.collect.Iterables;
+import java.util.Arrays;
 
 import junit.framework.TestCase;
 
@@ -62,8 +60,9 @@ public class EpfFileModelWriterTest extends TestCase {
   }
 
   private void assertLine(String substring, String string) {
+    String[] lines = string.split("\\R");
     assertTrue("Could not find line [" + substring + "] in [" + string + "]",
-        Iterables.contains(Splitter.on('\n').split(string), substring));
+        Arrays.stream(lines).anyMatch(s -> s.equals(substring)));
   }
 
   private void assertBasics(String actual) {

--- a/parent/tests/com.google.eclipse.mechanic.tests/src/com/google/eclipse/mechanic/internal/MechanicConfigurationVariableInitializerTest.java
+++ b/parent/tests/com.google.eclipse.mechanic.tests/src/com/google/eclipse/mechanic/internal/MechanicConfigurationVariableInitializerTest.java
@@ -8,10 +8,12 @@
  *******************************************************************************/
 package com.google.eclipse.mechanic.internal;
 
+import java.io.File;
 import java.util.Properties;
 
 import junit.framework.TestCase;
 
+import org.eclipse.core.runtime.Path;
 import org.eclipse.core.variables.IValueVariable;
 
 import com.google.eclipse.mechanic.tests.internal.RunAsPluginTest;
@@ -33,7 +35,8 @@ public class MechanicConfigurationVariableInitializerTest extends TestCase {
         return properties;
       }
     }.initialize(variable);
-    assertEquals("/path/to/eclipse!configuration!com.google.eclipse.mechanic",
+    assertEquals( File.separatorChar + "path" + File.separatorChar + "to" + File.separatorChar
+        + "eclipse!configuration!com.google.eclipse.mechanic",
         variable.getValue());
   }
 }

--- a/parent/tests/com.google.eclipse.mechanic.tests/src/com/google/eclipse/mechanic/internal/MechanicConfigurationVariableInitializerTest.java
+++ b/parent/tests/com.google.eclipse.mechanic.tests/src/com/google/eclipse/mechanic/internal/MechanicConfigurationVariableInitializerTest.java
@@ -13,7 +13,6 @@ import java.util.Properties;
 
 import junit.framework.TestCase;
 
-import org.eclipse.core.runtime.Path;
 import org.eclipse.core.variables.IValueVariable;
 
 import com.google.eclipse.mechanic.tests.internal.RunAsPluginTest;

--- a/parent/tests/com.google.eclipse.mechanic.tests/src/com/google/eclipse/mechanic/plugin/core/MechanicPreferencesTest.java
+++ b/parent/tests/com.google.eclipse.mechanic.tests/src/com/google/eclipse/mechanic/plugin/core/MechanicPreferencesTest.java
@@ -9,6 +9,7 @@
 
 package com.google.eclipse.mechanic.plugin.core;
 
+import java.io.File;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -115,7 +116,9 @@ public class MechanicPreferencesTest extends TestCase {
     setToDefault(IMechanicPreferences.DIRS_PREF);
 
     String taskDirs = mechanicPreferences.getString(IMechanicPreferences.DIRS_PREF);
-    assertEquals("${user_homedir}/.eclipse/mechanic:${mechanic_configuration_path}/mechanic", taskDirs);
+    assertEquals("${user_homedir}" + File.separatorChar + ".eclipse" + File.separatorChar + "mechanic"
+        + File.pathSeparatorChar + "${mechanic_configuration_path}" + File.separatorChar + "mechanic",
+        taskDirs);
   }
 
   public void testContains() {

--- a/parent/tests/pom.xml
+++ b/parent/tests/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.google.eclipse.mechanic</groupId>
         <artifactId>parent</artifactId>
-        <version>0.5.2-SNAPSHOT</version>
+        <version>0.6.0-SNAPSHOT</version>
     </parent>
     <modules>
         <module>com.google.eclipse.mechanic.tests</module>
@@ -18,8 +18,7 @@
     <dependencies>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>1.10.19</version>
+            <artifactId>mockito-core</artifactId>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
The plugin stopped applying/syncing external configurations sometime around Eclipse 2022-12. I have done some upgrades to tooling and dependencies and built the plugin locally. With this local version, it is working again correctly (as of Eclipse 2023-06).

These are the changes I made:
- Raised plugin version number to (non-official) 0.6.0.
- Upgraded Maven build plugins to recent versions.
- Upgraded depencencies (including Eclipse API) to a recent version. Dependency versions are now managed by the parent POM.
- Upgraded to Java 17.
- Fixed code to compile against the new API and replaced deprecated calls with their respective substitutions.
- Fixed unit tests to also run successfully on a Windows system.

There were a few steps that I did not manage to solve cleanly, so I just worked around them to be able to build the plugin locally:
- Commented out Tycho Build Timestamp from JGit in packaging step because it was not working on my end.
- Commented out SonarQube Scanner in build because I am not the official repository maintainer and the currently configured endpoint seems unavailable.